### PR TITLE
chore: ensure that the PR title follows "Conventional Commits"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# See https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: thursday
+    open-pull-requests-limit: 2
+    rebase-strategy: "disabled"
+    commit-message:
+      prefix: "chore(gha)"
+    labels:
+      - dependencies
+      - github_actions
+      - skip-changelog
+    reviewers:
+      - process-analytics/pa-collaborators

--- a/.github/workflows/pr-metadata-checks.yml
+++ b/.github/workflows/pr-metadata-checks.yml
@@ -1,0 +1,14 @@
+name: Check Pull Request Metadata
+on:
+  pull_request_target:
+    # trigger when the PR title changes
+    types: [opened, edited, reopened]
+
+jobs:
+  pr-title:
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write # post comments when the PR title doesn't match the "Conventional Commits" rules
+    steps:
+      - name: Check Pull Request title
+        uses: bonitasoft/actions/packages/pr-title-conventional-commits@v2


### PR DESCRIPTION
Related changes:
- Add a dedicated workflow to enforce the rule. It runs on `pull_request_target` to handle PR created by Dependabot and from fork repositories.
- Dependabot configuration: added to automatically GitHub Actions.

### Notes

**Rationale**: see https://github.com/orgs/process-analytics/projects/6/views/1?pane=info

See also https://github.com/process-analytics/github-actions-playground/issues/213 and https://github.com/process-analytics/github-actions-playground/issues/224
