### PR TITLE
feat: update edge style

### DIFF
--- a/backend-mock-server/src/app.service.ts
+++ b/backend-mock-server/src/app.service.ts
@@ -12,11 +12,11 @@ export class AppService {
 
   getFrequencyStats(): FrequencyStats {
     return {
-      'Assign Approver': 65,
-      'Approve Invoice': 113,
-      'Clarify Invoice': 48,
-      'Prepare Bank Transfer': 107,
-      'Archive Invoice': 107,
+      'Activity_1': 65, // 'Assign Approver'
+      'Activity_1omool6': 113, // 'Approve Invoice'
+      'Activity_1pkoaqu': 48, // 'Clarify Invoice'
+      'Activity_1gv7jjb': 107, // 'Prepare Bank Transfer'
+      'Activity_11n0ixn': 107, // 'Archive Invoice'
     };
   }
 

--- a/backend-mock-server/src/app.service.ts
+++ b/backend-mock-server/src/app.service.ts
@@ -12,11 +12,18 @@ export class AppService {
 
   getFrequencyStats(): FrequencyStats {
     return {
+      // Shapes
       'Activity_1': 65, // 'Assign Approver'
       'Activity_1omool6': 113, // 'Approve Invoice'
       'Activity_1pkoaqu': 48, // 'Clarify Invoice'
       'Activity_1gv7jjb': 107, // 'Prepare Bank Transfer'
       'Activity_11n0ixn': 107, // 'Archive Invoice'
+      // Edges
+      'Flow_1w8ldp8': 65, // between 'Assign Approver' and 'Approve Invoice'
+      'Flow_1pl5mvt': 113, // between 'Approve Invoice' and gateway
+      'Flow_0odkkje': 48, // between gateway and 'Clarify Invoice'
+      'Flow_09havhs': 48, // between gateway and 'Approve Invoice'
+      'Flow_1x81xda': 107, // between gateway and 'Archive Invoice'
     };
   }
 

--- a/frontend/src/discovery.js
+++ b/frontend/src/discovery.js
@@ -4,7 +4,7 @@ import { FitType, mxgraph, ShapeBpmnElementKind } from 'bpmn-visualization';
 import { frequencyScale } from './colors.js'
 import { getFrequencyOverlay } from './overlays.js';
 import { colorLegend, overlayLegend } from './legend.js';
-import { apiUrl } from './utils.js';
+import { apiUrl, mapFrequencyToWidth } from './utils.js';
 
 export function getBPMNDiagram(formData) {
     console.log('Get bpmn...');
@@ -91,8 +91,16 @@ function visualizeFrequency(data) {
                     bpmnElement.bpmnSemantic.id,
                     getFrequencyOverlay(freqNum, max, myFrequencyScale(freqNum), 'top-right'));
             }
-            // Add overlay on edge
+            // Update edge style and add overlay on edge
             else {
+                const edgeWidth = mapFrequencyToWidth(freqNum, 0, max, 0, 5);
+                globals.bpmnVisualization.bpmnElementsRegistry.updateStyle(eltId, {
+                    stroke:{
+                        width: edgeWidth,
+                        color: myFrequencyScale(freqNum)
+                    }
+                });
+
                 globals.bpmnVisualization.bpmnElementsRegistry.addOverlays(
                     bpmnElement.bpmnSemantic.id,
                     getFrequencyOverlay(freqNum, max, myFrequencyScale(freqNum), 'middle'));
@@ -106,7 +114,7 @@ function visualizeFrequency(data) {
     //add legend
     colorLegend({
         colorScale: myFrequencyScale,
-        title: 'Frequency of execution'
+        title: 'Frequency of execution (absolute)'
     });
 
     overlayLegend({rightOverlayLegend : '# executions'});

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -9,3 +9,12 @@ export function getBpmnActivityElementbyName(activityName){
 
 // for both backend and backend-mock-server
 export const apiUrl = 'http://localhost:6969';
+
+// Linear mapping function to return an edge width based on the frequency
+export function mapFrequencyToWidth(frequency, minFrequency, maxFrequency, minWidth, maxWidth) {
+    const range = maxFrequency - minFrequency;
+    const fraction = (frequency - minFrequency) / range;
+    const widthRange = maxWidth - minWidth;
+    const width = minWidth + (fraction * widthRange);
+    return width;
+}

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -15,6 +15,5 @@ export function mapFrequencyToWidth(frequency, minFrequency, maxFrequency, minWi
     const range = maxFrequency - minFrequency;
     const fraction = (frequency - minFrequency) / range;
     const widthRange = maxWidth - minWidth;
-    const width = minWidth + (fraction * widthRange);
-    return width;
+    return minWidth + (fraction * widthRange);
 }


### PR DESCRIPTION
The width and color of the edges are updated based on frequency. This style is commonly used in existing tools.
For consistency, the same color scheme is used as for activities.

**Before:**

<img width="699" alt="without-edge-style" src="https://github.com/process-analytics/bpmn-visualization-pm4py/assets/67027776/ff0482fa-a4e6-490c-8d0f-1b05d3d9053e">

**After:**

![update-edge-style](https://github.com/process-analytics/bpmn-visualization-pm4py/assets/67027776/4a61d01d-4a30-46a0-8c92-5da295686277)

closes #33 
