### PR TITLE
bug: check NaN frequencies

### DIFF
--- a/frontend/src/discovery.js
+++ b/frontend/src/discovery.js
@@ -71,8 +71,8 @@ function visualizeFrequency(data) {
     for (const [eltId, freqValue] of Object.entries(data)) {
         const freqNum = parseInt(freqValue);
 
-        // freqNum may be NaN if the BPMN element has never been executed
-        // Add frequency related statistics only of freqNum is not null
+        // freqValue is None if the BPMN element has never been executed
+        // Add frequency related statistics only if freqNum is not NaN
         if(!isNaN(freqNum)){
             const bpmnElement = globals.bpmnVisualization.bpmnElementsRegistry.getElementsByIds(eltId)[0];
         

--- a/frontend/src/discovery.js
+++ b/frontend/src/discovery.js
@@ -70,44 +70,49 @@ function visualizeFrequency(data) {
     //iterate over the elements (activities and edges) and set their color by calling the frequency color scale function
     for (const [eltId, freqValue] of Object.entries(data)) {
         const freqNum = parseInt(freqValue);
-        const bpmnElement = globals.bpmnVisualization.bpmnElementsRegistry.getElementsByIds(eltId)[0];
+
+        // freqNum may be NaN if the BPMN element has never been executed
+        // Add frequency related statistics only of freqNum is not null
+        if(!isNaN(freqNum)){
+            const bpmnElement = globals.bpmnVisualization.bpmnElementsRegistry.getElementsByIds(eltId)[0];
         
-        if(bpmnElement){
-            // Update style of activity element
-            if (bpmnElement.bpmnSemantic.isShape) {
-                const fontColor = freqNum > avg ? 'white' : 'default';
+            if(bpmnElement){
+                // Update style of activity element
+                if (bpmnElement.bpmnSemantic.isShape) {
+                    const fontColor = freqNum > avg ? 'white' : 'default';
 
-                globals.bpmnVisualization.bpmnElementsRegistry.updateStyle(eltId,{
-                    fill: {
-                        color: myFrequencyScale(freqNum)
-                    },
-                    font: {
-                        color: fontColor
-                    }
-                });
+                    globals.bpmnVisualization.bpmnElementsRegistry.updateStyle(eltId,{
+                        fill: {
+                            color: myFrequencyScale(freqNum)
+                        },
+                        font: {
+                            color: fontColor
+                        }
+                    });
 
-                //add frequency overlay
-                globals.bpmnVisualization.bpmnElementsRegistry.addOverlays(
-                    bpmnElement.bpmnSemantic.id,
-                    getFrequencyOverlay(freqNum, max, myFrequencyScale(freqNum), 'top-right'));
+                    //add frequency overlay
+                    globals.bpmnVisualization.bpmnElementsRegistry.addOverlays(
+                        bpmnElement.bpmnSemantic.id,
+                        getFrequencyOverlay(freqNum, max, myFrequencyScale(freqNum), 'top-right'));
+                }
+                // Update edge style and add overlay on edge
+                else {
+                    const edgeWidth = mapFrequencyToWidth(freqNum, 0, max, 0, 5);
+                    globals.bpmnVisualization.bpmnElementsRegistry.updateStyle(eltId, {
+                        stroke:{
+                            width: edgeWidth,
+                            color: myFrequencyScale(freqNum)
+                        }
+                    });
+
+                    globals.bpmnVisualization.bpmnElementsRegistry.addOverlays(
+                        bpmnElement.bpmnSemantic.id,
+                        getFrequencyOverlay(freqNum, max, myFrequencyScale(freqNum), 'middle'));
+                }
             }
-            // Update edge style and add overlay on edge
-            else {
-                const edgeWidth = mapFrequencyToWidth(freqNum, 0, max, 0, 5);
-                globals.bpmnVisualization.bpmnElementsRegistry.updateStyle(eltId, {
-                    stroke:{
-                        width: edgeWidth,
-                        color: myFrequencyScale(freqNum)
-                    }
-                });
-
-                globals.bpmnVisualization.bpmnElementsRegistry.addOverlays(
-                    bpmnElement.bpmnSemantic.id,
-                    getFrequencyOverlay(freqNum, max, myFrequencyScale(freqNum), 'middle'));
+            else{
+                console.log(`did not find the element of id ${eltId}`)
             }
-        }
-        else{
-            console.log(`did not find the element of id ${eltId}`)
         }
     }
 


### PR DESCRIPTION
When computing frequency statistics, pm4py returns 'None' for elements that are not visited during the alignment phase. Frequency statistics were added without a prior check for NaN frequency values which generated errors and resulted in an unexpected behavior in the frontend part (overlays with NaN labels, see figure below)

![bug-discovery](https://github.com/process-analytics/bpmn-visualization-pm4py/assets/67027776/0b8c122f-041c-4e2a-a9cd-35115e7b7f9c)

After the fix, no style or overlays are added to elements that have not been visited and therefore do not have a frequency:

![after-bug-nan-fix](https://github.com/process-analytics/bpmn-visualization-pm4py/assets/67027776/90b927fd-dc98-4ad0-ab75-7484a1c6283a)



